### PR TITLE
Update the searcher to not override the method entirely

### DIFF
--- a/lib/spree/search/multi_domain.rb
+++ b/lib/spree/search/multi_domain.rb
@@ -1,13 +1,8 @@
 module Spree::Search
   class MultiDomain < Spree::Core::Search::Base
     def get_base_scope
-      base_scope = @cached_product_group ? @cached_product_group.products.available : Spree::Product.available
-      base_scope = base_scope.by_store(current_store_id) if current_store_id
-      base_scope = base_scope.in_taxon(taxon) unless taxon.blank?
-
-      base_scope = get_products_conditions_for(base_scope, keywords) unless keywords.blank?
-
-      base_scope = add_search_scopes(base_scope)
+      base_scope = super
+      base_scope = base_scope.by_store(@properties[:current_store_id]) if @properties[:current_store_id]
       base_scope
     end
 


### PR DESCRIPTION
I am not sure why the entire method is overriden. I noticed because solidus has been updated and some things like `add_eagerload_scopes` where not performed. 😨 
Now: that's the version we are currently using in our shops, where it just adds the filter for the current_store.